### PR TITLE
Bump up activesupport and others

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,23 +6,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.6)
+    activesupport (5.2.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     ast (2.4.0)
-    ast_utils (0.1.0)
+    ast_utils (0.3.0)
       parser (~> 2.4)
-      thor (~> 0.19.4)
+      thor (>= 0.19)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
-    i18n (1.0.1)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
-    minitest (5.11.3)
-    parser (2.5.1.0)
+    minitest (5.14.1)
+    parser (2.7.1.3)
       ast (~> 2.4.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -46,14 +46,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    steep (0.4.0)
-      activesupport (~> 5.1.0)
-      ast_utils (~> 0.1.0)
+    steep (0.9.0)
+      activesupport (~> 5.1)
+      ast_utils (~> 0.3.0)
       parser (~> 2.4)
-      rainbow (~> 2.2.2)
-    thor (0.19.4)
+      rainbow (~> 2.2.2, < 4.0)
+    thor (1.0.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     yard (0.9.20)
 
@@ -66,8 +66,8 @@ DEPENDENCIES
   pry-doc
   rake (~> 13.0)
   rspec (~> 3.2)
-  steep (= 0.4.0)
+  steep
   yard2steep!
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/yard2steep.gemspec
+++ b/yard2steep.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-doc"
-  spec.add_development_dependency "steep", "0.4.0"
+  spec.add_development_dependency "steep"
 end


### PR DESCRIPTION
## WHY
A vulnerability was found in activesupport https://github.com/advisories/GHSA-2p68-f74v-9wc6

## WHAT
Bump up activesupport and others.
This only affects the development environment.